### PR TITLE
Fix: Close modal after saving product and clear input fields when adding new product

### DIFF
--- a/frontend/src/pages/ProductPage.jsx
+++ b/frontend/src/pages/ProductPage.jsx
@@ -21,6 +21,12 @@ function ProductPage() {
     fetchProduct(id);
   }, [fetchProduct, id]);
 
+  const handleUpdate = async(e) => {
+      e.preventDefault();
+      await updateProduct(id);
+      navigate("/");
+  }
+
   const handleDelete = async () => {
     if (window.confirm("Are you sure you want to delete this product?")) {
       await deleteProduct(id);
@@ -67,10 +73,7 @@ function ProductPage() {
             <h2 className="card-title text-2xl mb-6">Edit Product</h2>
 
             <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                updateProduct(id);
-              }}
+              onSubmit={handleUpdate}
               className="space-y-6"
             >
               {/* PRODUCT NAME */}

--- a/frontend/src/pages/ProductPage.jsx
+++ b/frontend/src/pages/ProductPage.jsx
@@ -23,8 +23,8 @@ function ProductPage() {
 
   const handleUpdate = async(e) => {
       e.preventDefault();
-      await updateProduct(id);
-      navigate("/");
+      const ok = await updateProduct(id);
+      if (ok) navigate("/");
   }
 
   const handleDelete = async () => {

--- a/frontend/src/store/useProductStore.js
+++ b/frontend/src/store/useProductStore.js
@@ -94,9 +94,11 @@ export const useProductStore = create((set, get) => ({
       set({ currentProduct: response.data.data });
       get().resetForm();  // reset form after update product
       toast.success("Product updated successfully");
+      return true;
     } catch (error) {
       toast.error("Something went wrong");
       console.log("Error in updateProduct function", error);
+      return false;
     } finally {
       set({ loading: false });
     }

--- a/frontend/src/store/useProductStore.js
+++ b/frontend/src/store/useProductStore.js
@@ -85,12 +85,14 @@ export const useProductStore = create((set, get) => ({
       set({ loading: false });
     }
   },
+
   updateProduct: async (id) => {
     set({ loading: true });
     try {
       const { formData } = get();
       const response = await axios.put(`${BASE_URL}/api/products/${id}`, formData);
       set({ currentProduct: response.data.data });
+      get().resetForm();  // reset form after update product
       toast.success("Product updated successfully");
     } catch (error) {
       toast.error("Something went wrong");


### PR DESCRIPTION
This PR addresses two issues in the product modal workflow:

1. Modal not closing after update
- Previously, when updating a product and clicking Save Changes, the modal stayed open.
- Now, the modal automatically closes after the update is successfully saved.

2. Input fields not cleared when adding a new product
- Previously, when adding a new product, the form retained data from the last updated product.
- Now, input fields are reset after successfully adding a product, ensuring a clean form for the next entry.

Changes Made are made in ProductPage.jsx and useProductStore file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product update now resets the edit form automatically after a successful save, clearing inputs for the next action.
  * After saving a product, the app will navigate back to the main page only when the update succeeds, preventing premature redirects and improving user flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->